### PR TITLE
Fixes for Windows and node 0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var join = require('path').join;
 var relative = require('path').relative;
 var sep = require('path').sep;
 
-var mismatchRe = /Module version mismatch/
-var winRe = /A dynamic link library \(DLL\) initialization routine failed/
+var mismatchRe = /Module version mismatch/;
+var winRe = /A dynamic link library \(DLL\) initialization routine failed/;
 
 module.exports = patch;
 
@@ -19,7 +19,7 @@ function patch(opts){
     try {
       ret = load.call(Module, request, parent);
     } catch (err) {
-      if (!mismatchRe.test(err.message) && !winRe.test(err.message)) throw err
+      if (!mismatchRe.test(err.message) && !winRe.test(err.message)) throw err;
 
       var segs = resolve(dirname(parent.id), request).split(sep);
       var path = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
@@ -34,7 +34,7 @@ function patch(opts){
       var ps;
 
       if (prebuild) {
-        var bin = join(require.resolve('prebuild'), '../bin.js')
+        var bin = join(require.resolve('prebuild'), '../bin.js');
         ps = spawnSync(bin, [
           '--install',
           '--abi=' + process.versions.modules

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "juliangruber/require-rebuild",
   "description": "Rebuild modules if built for a different node versions",
   "dependencies": {
+    "cross-spawn": "~2.1.5",
     "extend": "^3.0.0",
     "prebuild": "^2.9.0"
   },


### PR DESCRIPTION
- Use `cross-spawn` because it fixes various Windows issues and has a `spawnSync` fallback for node 0.10. It has a native dependency itself (`thread-sleep`), but that's not a problem because that dep is wrapped in a try-catch with a fallback.
- I observed the error `A dynamic link library (DLL) initialization routine failed` instead of `Module version mismatch`, so I've added a second regex to test for this (but maybe the message is too broad)
- Made the path stuff in `patch()` platform-independent

Tested with leveldown on node 0.10.41, 4.2.5 and 5.5.0. Got various permission errors on 0.11 and 0.12, probably unrelated to `require-rebuild` so I didn't bother.
