### PR TITLE
Node 0.10 segfaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var dirname = require('path').dirname;
 var join = require('path').join;
 var relative = require('path').relative;
 var sep = require('path').sep;
+var extname = require('path').extname;
 var home = require('user-home');
 
 var mismatchRe = /Module version mismatch/;
@@ -16,58 +17,100 @@ module.exports = patch;
 
 function patch(opts){
   var load = Module._load;
-  Module._load = function(request, parent){
-    var ret;
-    try {
-      ret = load.call(Module, request, parent);
-    } catch (err) {
-      if (!mismatchRe.test(err.message) && !winRe.test(err.message)) throw err;
+  var version = process.versions.node.split('.');
 
-      var resolved = resolveSync(request, {
-        basedir: dirname(parent.id),
-        extensions: ['.js', '.json', '.node']
-      });
-      var segs = resolved.split(sep);
-      var path = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
-
-      console.error('Recompiling %s...', relative(process.cwd(), path));
-
-      // prebuild or node-gyp
-      var pkg = require(join(path, 'package.json'));
-      var reg = /prebuild/;
-      var prebuild = pkg.scripts
-        && (reg.test(pkg.scripts.install) || reg.test(pkg.scripts.prebuild));
-      var ps;
-
-      if (prebuild) {
-        var bin = join(require.resolve('prebuild'), '../bin.js');
-        ps = spawnSync(bin, [
-          '--install',
-          '--abi=' + process.versions.modules,
-          '--target=' + process.versions.node
-        ], {
-          cwd: path,
-          stdio: 'inherit'
-        });
-      } else {
-        ps = spawnSync('node-gyp', [
-          'rebuild',
-          '--target=' + process.versions.node
-        ], {
-          cwd: path,
-          env: extend(process.env, {
-            'HOME': gypHome,
-            'USERPROFILE': gypHome
-          }),
-          stdio: 'inherit'
-        });
+  // node 0.10 segfaults if the native module fails to load
+  if (version[0] === '0' && version[1] === '10') {
+    Module._load = function(request, parent){
+      if (extname(request) === '.node') {
+        var resolved = resolveRequest(request, parent);
+        if (shouldRebuild(resolved)) rebuild(resolved);
       }
 
-      if (ps.error) throw ps.error;
-      console.error('Done!');
       return load.call(Module, request, parent);
-    }
-    return ret;
-  };
+    };
+  } else {
+    Module._load = function(request, parent){
+      try {
+        return load.call(Module, request, parent);
+      } catch (err) {
+        if (!isMismatchError(err.message)) throw err;
+        rebuild(resolveRequest(request, parent));
+        return load.call(Module, request, parent);
+      }
+    };
+  }
+
   return require;
+}
+
+function shouldRebuild(path) {
+  // Try to require the native module in a second process.
+  // It will still segfault, but.. fingers crossed?
+  var ps = spawnSync('node', [
+    '-e',
+    'require("' + path.replace(/\\/g, '/') + '")'
+  ], {
+    cwd: __dirname,
+    stdio: [ 'ignore', 'ignore', 'pipe' ]
+  });
+
+  if (ps.error) throw ps.error;
+  if (ps.status === 0) return false;
+
+  var stderr = ps.stderr.toString();
+  if (isMismatchError(stderr)) return true;
+  else throw new Error(stderr);
+}
+
+function rebuild(path) {
+  var segs = path.split(sep);
+  var root = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
+
+  console.error('Recompiling %s...', relative(process.cwd(), root));
+
+  // prebuild or node-gyp
+  var pkg = require(join(root, 'package.json'));
+  var reg = /prebuild/;
+  var prebuild = pkg.scripts
+    && (reg.test(pkg.scripts.install) || reg.test(pkg.scripts.prebuild));
+  var ps;
+
+  if (prebuild) {
+    var bin = join(require.resolve('prebuild'), '../bin.js');
+    ps = spawnSync(bin, [
+      '--install',
+      '--abi=' + process.versions.modules,
+      '--target=' + process.versions.node
+    ], {
+      cwd: root,
+      stdio: 'inherit'
+    });
+  } else {
+    ps = spawnSync('node-gyp', [
+      'rebuild',
+      '--target=' + process.versions.node
+    ], {
+      cwd: root,
+      env: extend(process.env, {
+        'HOME': gypHome,
+        'USERPROFILE': gypHome
+      }),
+      stdio: 'inherit'
+    });
+  }
+
+  if (ps.error) throw ps.error;
+  console.error('Done!');
+}
+
+function isMismatchError(msg) {
+  return mismatchRe.test(msg) || winRe.test(msg);
+}
+
+function resolveRequest(request, parent) {
+  return resolveSync(request, {
+    basedir: dirname(parent.id),
+    extensions: ['.js', '.json', '.node']
+  });
 }


### PR DESCRIPTION
I thought `require-rebuild` worked fine on node 0.10, but it actually exits with code -1073741819, which I believe means node crashed with a segfault.

The segfault (or something else) happens just before the process exits (this is why it fooled me), and only when requiring the native module threw an error (regardless of whether you catch it, rebuild, or call Module._load again, nothing else matters).

I'm out of my depth to find the real (node/c/v8) issue, the only discrepancy I could discover in the JS world is this:

![screenshot require-rebuild debug](https://cloud.githubusercontent.com/assets/3055345/12691960/718b284a-c6f1-11e5-8e92-746eee24beb3.png)

I.e. the old state of the module metadata is not replaced after rebuild, instead, the module is listed twice. Correcting that had no effect.

This PR adds a nasty workaround for node 0.10. Instead of rebuilding when an error occurred, it takes a pro-active approach. For each `*.node` module request, it spawns another node process to test if the module can be required without error. Else, rebuild.

Obviously this is not ideal (it's fast enough, but you still get a possibly dangerous segfault in the child process), so take this as a discussion starter, not necessarily as a ready-to-go PR.
