### PR TITLE
Handle special cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ addons:
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh
   - nvm install 0.10
+  - nvm exec 0.10 npm i -g npm@latest-2
+  - nvm exec 0.10 npm i -g node-gyp
   - nvm install 4.2
+  - nvm exec 4.2 npm i -g node-gyp
   - nvm install 5.5
+  - nvm exec 5.5 npm i -g node-gyp
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
   - $CXX --version
   - nvm exec 5.5 npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+os:
+  - linux
+  - osx
+sudo: false
+language: cpp
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+install:
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh
+  - nvm install 0.10
+  - nvm install 4.2
+  - nvm install 5.5
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
+  - $CXX --version
+  - nvm exec 5.5 npm install
+script:
+  - nvm run 5.5 test.js
+  - nvm run 4.2 test.js
+  - nvm run 0.10 test.js
+  - nvm run 4.2 test.js
+  - nvm run 5.5 test.js

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var mismatchRe = /Module version mismatch/;
 var winRe = /A dynamic link library \(DLL\) initialization routine failed/;
 var legacyRe = /undefined symbol: node_module_register/;
 var gypHome = join(home, '.node-gyp');
+var visited = {}
 
 module.exports = patch;
 
@@ -67,6 +68,9 @@ function shouldRebuild(path) {
 function rebuild(path) {
   var segs = path.split(sep);
   var root = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
+
+  if (visited[root]) return;
+  else visited[root] = true;
 
   console.error('Recompiling %s...', relative(process.cwd(), root));
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var regexes = [
 ];
 
 var gypHome = join(home, '.node-gyp');
-var visited = {}
+var visited = {};
 
 module.exports = patch;
 
@@ -51,7 +51,7 @@ function patch(opts){
   return require;
 }
 
-function shouldRebuild(path) {
+function shouldRebuild(path){
   // Try to require the native module in a second process.
   // It will still segfault, but.. fingers crossed?
   var ps = spawnSync('node', [
@@ -70,7 +70,7 @@ function shouldRebuild(path) {
   else throw new Error(stderr);
 }
 
-function rebuild(path) {
+function rebuild(path){
   var segs = path.split(sep);
   var root = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
 
@@ -114,13 +114,13 @@ function rebuild(path) {
   console.error('Done!');
 }
 
-function isMismatchError(msg) {
+function isMismatchError(msg){
   for (var i=0; i < regexes.length; i++) {
-    if (regexes[i].test(msg)) return true
+    if (regexes[i].test(msg)) return true;
   }
 }
 
-function resolveRequest(request, parent) {
+function resolveRequest(request, parent){
   return resolveSync(request, {
     basedir: dirname(parent.id),
     extensions: ['.js', '.json', '.node']

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var dirname = require('path').dirname;
 var join = require('path').join;
 var relative = require('path').relative;
 var sep = require('path').sep;
+var extname = require('path').extname;
 var home = require('user-home');
 
 var mismatchRe = /Module version mismatch/;
@@ -16,58 +17,100 @@ module.exports = patch;
 
 function patch(opts){
   var load = Module._load;
-  Module._load = function(request, parent){
-    var ret;
-    try {
-      ret = load.call(Module, request, parent);
-    } catch (err) {
-      if (!mismatchRe.test(err.message) && !winRe.test(err.message)) throw err;
+  var version = process.versions.node.split('.');
 
-      var resolved = resolveSync(request, {
-        basedir: dirname(parent.id),
-        extensions: ['.js', '.json', '.node']
-      });
-      var segs = resolved.split(sep);
-      var path = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
-
-      console.error('Recompiling %s...', relative(process.cwd(), path));
-
-      // prebuild or node-gyp
-      var pkg = require(join(path, 'package.json'));
-      var reg = /prebuild/;
-      var prebuild = pkg.scripts
-        && (reg.test(pkg.scripts.install) || reg.test(pkg.scripts.prebuild));
-      var ps;
-
-      if (prebuild) {
-        var bin = join(require.resolve('prebuild'), '../bin.js');
-        ps = spawnSync(bin, [
-          '--install',
-          '--abi=' + process.versions.modules,
-          '--target=' + process.versions.node
-        ], {
-          cwd: path,
-          stdio: 'inherit'
-        });
-      } else {
-        ps = spawnSync('node-gyp', [
-          'rebuild',
-          '--target=' + process.versions.node
-        ], {
-          cwd: path,
-          env: extend(process.env, {
-            'HOME': gypHome,
-            'USERPROFILE': gypHome
-          }),
-          stdio: 'inherit'
-        });
+  // node 0.10 segfaults if the native module fails to load
+  if (version[0] === '0' && version[1] === '10') {
+    Module._load = function(request, parent){
+      if (extname(request) === '.node') {
+        var resolved = resolveRequest(request, parent);
+        if (shouldRebuild(resolved)) rebuild(resolved);
       }
 
-      if (ps.error) throw ps.error;
-      console.error('Done!');
       return load.call(Module, request, parent);
-    }
-    return ret;
-  };
+    };
+  } else {
+    Module._load = function(request, parent){
+      try {
+        return load.call(Module, request, parent);
+      } catch (err) {
+        if (!isMismatchError(err.message)) throw err;
+        rebuild(resolveRequest(request, parent));
+        return load.call(Module, request, parent);
+      }
+    };
+  }
+
   return require;
+}
+
+function shouldRebuild(path) {
+  // Try to require the native module in a second process.
+  // It will still segfault, but.. fingers crossed?
+  var ps = spawnSync('node', [
+    '-e',
+    'require("' + path.replace(/\\/g, '/') + '")'
+  ], {
+    cwd: __dirname,
+    stdio: [ 'ignore', 'ignore', 'pipe' ]
+  });
+
+  if (ps.error) throw ps.error;
+  if (ps.status === 0) return false;
+
+  var stderr = ps.stderr.toString();
+  if (isMismatchError(stderr)) return true;
+  else throw new Error(stderr);
+}
+
+function rebuild(path) {
+  var segs = path.split(sep);
+  var root = segs.slice(0, segs.indexOf('node_modules') + 2).join(sep);
+
+  console.error('Recompiling %s...', relative(process.cwd(), root));
+
+  // prebuild or node-gyp
+  var pkg = require(join(root, 'package.json'));
+  var reg = /prebuild/;
+  var prebuild = pkg.scripts
+    && (reg.test(pkg.scripts.install) || reg.test(pkg.scripts.prebuild));
+  var ps;
+
+  if (prebuild) {
+    var bin = join(require.resolve('prebuild'), '../bin.js');
+    ps = spawnSync(bin, [
+      '--install',
+      '--abi=' + process.versions.modules,
+      '--target=' + process.versions.node
+    ], {
+      cwd: root,
+      stdio: 'inherit'
+    });
+  } else {
+    ps = spawnSync('node-gyp', [
+      'rebuild',
+      '--target=' + process.versions.node
+    ], {
+      cwd: root,
+      env: extend(process.env, {
+        'HOME': gypHome,
+        'USERPROFILE': gypHome
+      }),
+      stdio: 'inherit'
+    });
+  }
+
+  if (ps.error) throw ps.error;
+  console.error('Done!');
+}
+
+function isMismatchError(msg) {
+  return mismatchRe.test(msg) || winRe.test(msg);
+}
+
+function resolveRequest(request, parent) {
+  return resolveSync(request, {
+    basedir: dirname(parent.id),
+    extensions: ['.js', '.json', '.node']
+  });
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function patch(opts){
   var version = process.versions.node.split('.');
 
   // node 0.10 segfaults if the native module fails to load
-  if (version[0] === '0' && version[1] === '10') {
+  if (version[0] === '0' && version[1] === '10' && false) {
     Module._load = function(request, parent){
       if (extname(request) === '.node') {
         var resolved = resolveRequest(request, parent);

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var home = require('user-home');
 
 var mismatchRe = /Module version mismatch/;
 var winRe = /A dynamic link library \(DLL\) initialization routine failed/;
+var legacyRe = /undefined symbol: node_module_register/;
 var gypHome = join(home, '.node-gyp');
 
 module.exports = patch;
@@ -105,7 +106,7 @@ function rebuild(path) {
 }
 
 function isMismatchError(msg) {
-  return mismatchRe.test(msg) || winRe.test(msg);
+  return mismatchRe.test(msg) || winRe.test(msg) || legacyRe.test(msg);
 }
 
 function resolveRequest(request, parent) {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   "devDependencies": {
     "a-native-module": "juliangruber/a-native-module",
     "a-native-module-without-prebuild": "^1.4.3",
-    "electron-prebuilt": "^0.36.4",
-    "frida": "^6.1.1",
-    "nsq.js": "^0.14.5"
+    "electron-prebuilt": "^0.36.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "license": "MIT",
   "repository": "juliangruber/require-rebuild",
   "description": "Rebuild modules if built for a different node versions",
+  "scripts": {
+    "test": "node -v && node test.js"
+  },
   "dependencies": {
     "cross-spawn": "~2.1.5",
     "extend": "^3.0.0",
@@ -14,6 +17,7 @@
   "devDependencies": {
     "a-native-module": "juliangruber/a-native-module",
     "a-native-module-without-prebuild": "^1.4.3",
-    "electron-prebuilt": "^0.36.4"
+    "electron-prebuilt": "^0.36.4",
+    "tape": "~4.4.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -14,6 +14,7 @@ function run(mod, t) {
 
   ps.on('error', t.fail.bind(t));
   ps.on('close', function(code){
+    if (code == null) code = 0;
     t.is(code, 0, 'exit code is 0');
 
     if (code !== 0) {

--- a/test.js
+++ b/test.js
@@ -2,8 +2,9 @@ var spawn = require('cross-spawn');
 var test = require('tape');
 
 function run(mod, t) {
-  t.plan(1)
+  t.plan(1);
 
+  var buf = '';
   var ps = spawn('node', [
     '-e',
     'require("./")();require("' + mod + '")'
@@ -13,13 +14,17 @@ function run(mod, t) {
 
   ps.on('error', t.fail.bind(t));
   ps.on('close', function(code){
-    t.is(code, 0, 'exit code is 0')
+    t.is(code, 0, 'exit code is 0');
+
+    if (code !== 0) {
+      buf.split(/[\r\n]+/).forEach(function(line){
+        if (line.trim()) t.comment(line);
+      });
+    }
   })
 
   ps.stderr.on('data', function(chunk) {
-    chunk.toString().split(/[\r\n]/).forEach(function(line){
-      t.comment(line)
-    })
+    buf+= chunk;
   })
 }
 

--- a/test.js
+++ b/test.js
@@ -1,0 +1,36 @@
+var spawn = require('cross-spawn');
+var test = require('tape');
+
+function run(mod, t) {
+  t.plan(1)
+
+  var ps = spawn('node', [
+    '-e',
+    'require("./")();require("' + mod + '")'
+  ], {
+    stdio: [ 'ignore', 'ignore', 'pipe' ]
+  });
+
+  ps.on('error', t.fail.bind(t));
+  ps.on('close', function(code){
+    t.is(code, 0, 'exit code is 0')
+  })
+
+  ps.stderr.on('data', function(chunk) {
+    chunk.toString().split(/[\r\n]/).forEach(function(line){
+      t.comment(line)
+    })
+  })
+}
+
+var modules = [
+  'a-native-module',
+  'a-native-module-without-prebuild',
+  'electron-prebuilt'
+];
+
+modules.forEach(function(mod){
+  test(mod, function(t){
+    run(mod, t);
+  });
+});

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var spawn = require('cross-spawn');
 var test = require('tape');
 
-function run(mod, t) {
+function run(mod, t){
   t.plan(1);
 
   var buf = '';
@@ -26,7 +26,7 @@ function run(mod, t) {
 
   ps.stderr.on('data', function(chunk) {
     buf+= chunk;
-  })
+  });
 }
 
 var modules = [


### PR DESCRIPTION
There are some special cases:
- Node 0.10 on Windows segfaults if the native module fails to load, regardless of whether the error is catched
- Same if Node 4+ tries to load a 0.10 module
- Node 0.10 on OSX doesn't throw an error, but exits with a SIGTRAP (I thought maybe that's an uncaught exception, but the output doesn't show a stack trace and I don't have a Mac to investigate further)

To handle these, `require-rebuild` does a pre-test on Windows (all node versions) and OSX (node 0.10). Every load request for a native module triggers the test once. The test `requires` the native module in a second process, and does a rebuild if that process doesn't exit with code 0.

Other changes and additions:
- Removed `frida` and `nsq` devDependencies because they're incompatible with Windows
- Add travis tests (loads and rebuilds the native modules in 5.5, 4.2, 0.10, back and forth)
